### PR TITLE
Add option to remove final blank line 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ymlthis (development version)
 
+* Add option `ymlthis.remove_blank_line`. If `TRUE`, YAML files will have their final lines removed (#42)
 * Synced arguments for `use_rmarkdown()` and `use_index_rmd()` and added `open_doc` argument to disable opening file (#41)
 * Fix bug where `usethis::write_over()` was not getting the `quiet` argument set correctly (issue #37)
 * Added `biblio_style` and `biblio_title` to `yml_citations()` (issue #40)

--- a/R/use_yml.R
+++ b/R/use_yml.R
@@ -193,6 +193,7 @@ write_yml_file <- function(.yml, path, build_ignore = FALSE, git_ignore = FALSE,
 
   if (!is.null(.yml)) {
     if (is.character(.yml) && length(.yml) == 1) {
+      if (check_remove_blank_line()) .yml <- remove_blank_line(.yml)
       usethis::write_over(path, .yml, quiet = quiet)
       return(invisible(path))
     }
@@ -203,6 +204,7 @@ write_yml_file <- function(.yml, path, build_ignore = FALSE, git_ignore = FALSE,
       column.major = FALSE
     )
 
+    if (check_remove_blank_line()) .yml <- remove_blank_line(.yml)
     usethis::write_over(path, yml_txt, quiet = quiet)
     return(invisible(path))
   }
@@ -215,6 +217,21 @@ write_yml_file <- function(.yml, path, build_ignore = FALSE, git_ignore = FALSE,
 
 file_path <- function(path, .file) {
   file.path(normalizePath(path), .file)
+}
+
+check_remove_blank_line <- function() {
+  remove_line_opt <- getOption("ymlthis.remove_blank_line")
+  option_set <- !is.null(remove_line_opt)
+  if (option_set) {
+    if (!is.logical(remove_line_opt)) stop("option `ymlthis.remove_blank_line` must be either logical or `NULL`")
+    return(remove_line_opt)
+  }
+
+  FALSE
+}
+
+remove_blank_line <- function(x) {
+  stringr::str_remove(x, "\n$")
 }
 
 

--- a/R/use_yml.R
+++ b/R/use_yml.R
@@ -124,7 +124,7 @@ return_yml_code <- function(.yml) {
 #' By default, the yaml package adds a new line to the end of files. Some
 #' environments, such as RStudio Projects, allow you to append new lines
 #' automatically. Thus, you may end up with 2 new lines at the end of your file.
-#' If you'd like to turn off this behavior, set
+#' If you'd like to automatically remove the last new line in the file, set
 #' `options(ymlthis.remove_blank_line = TRUE)`.
 #'
 #' @template describe_yml_param

--- a/R/use_yml.R
+++ b/R/use_yml.R
@@ -121,6 +121,12 @@ return_yml_code <- function(.yml) {
 #' [blogdown](https://bookdown.org/yihui/bookdown/configuration.html)
 #' documentation for more.
 #'
+#' By default, the yaml package adds a new line to the end of files. Some
+#' environments, such as RStudio Projects, allow you to append new lines
+#' automatically. Thus, you may end up with 2 new lines at the end of your file.
+#' If you'd like to turn off this behavior, set
+#' `options(ymlthis.remove_blank_line = TRUE)`.
+#'
 #' @template describe_yml_param
 #' @param path a file path to write the file to
 #' @param build_ignore Logical. Should the file be added to the `.Rbuildignore`

--- a/man/use_file_yml.Rd
+++ b/man/use_file_yml.Rd
@@ -57,6 +57,13 @@ YAML files specific to those packages; see the
 \href{https://bookdown.org/yihui/bookdown/configuration.html}{blogdown}
 documentation for more.
 }
+\details{
+By default, the yaml package adds a new line to the end of files. Some
+environments, such as RStudio Projects, allow you to append new lines
+automatically. Thus, you may end up with 2 new lines at the end of your file.
+If you'd like to turn off this behavior, set
+\code{options(ymlthis.remove_blank_line = TRUE)}.
+}
 \seealso{
 yml_bookdown_opts yml_bookdown_site yml_pkgdown yml_pkgdown_articles
 yml_pkgdown_docsearch yml_pkgdown_figures yml_pkgdown_news

--- a/man/use_file_yml.Rd
+++ b/man/use_file_yml.Rd
@@ -61,7 +61,7 @@ documentation for more.
 By default, the yaml package adds a new line to the end of files. Some
 environments, such as RStudio Projects, allow you to append new lines
 automatically. Thus, you may end up with 2 new lines at the end of your file.
-If you'd like to turn off this behavior, set
+If you'd like to automatically remove the last new line in the file, set
 \code{options(ymlthis.remove_blank_line = TRUE)}.
 }
 \seealso{


### PR DESCRIPTION
This PR adds the ability to automatically remove the final line of a YAML file by setting `options(ymlthis.remove_blank_line = TRUE)`. 

Closes #38. 

cc: @rich-iannone (it won't currently let me assign this to you to review, but please take a look when you have a chance)