### PR TITLE
update fieldguide to use new roxygen internal structures

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Suggests:
     knitr,
     pkgdown,
     prettydoc,
-    roxygen2,
+    roxygen2 (>= 7.0.0),
     spelling,
     testthat,
     xaringan
@@ -57,4 +57,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.0

--- a/man/asis_yaml_output.Rd
+++ b/man/asis_yaml_output.Rd
@@ -8,7 +8,7 @@ asis_yaml_output(.yml, fences = TRUE)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{fences}{Logical. Write fences ("---") before and after YAML?}
 }
@@ -17,23 +17,33 @@ a \code{yml_*()} function}
 instead of as an R object. Doing so adds code highlighting for YAML syntax.
 }
 \seealso{
-Other yml: \code{\link{bib2yml}},
-  \code{\link{draw_yml_tree}}, \code{\link{has_field}},
-  \code{\link{read_json}}, \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/bib2yml.Rd
+++ b/man/bib2yml.Rd
@@ -8,7 +8,7 @@ bib2yml(.yml = NULL, path)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{path}{a path to the .bib file}
 }
@@ -22,27 +22,38 @@ want to cite several R packages, see \code{\link[knitr:write_bib]{knitr::write_b
 bibliography file and convert it with \code{bib2yml()}.
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{draw_yml_tree}}, \code{\link{has_field}},
-  \code{\link{read_json}}, \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 
-Other citations: \code{\link{yml_citations}},
-  \code{\link{yml_reference}}
+Other citations: 
+\code{\link{yml_citations}()},
+\code{\link{yml_reference}()}
 }
 \concept{citations}
 \concept{yml}

--- a/man/code_chunk.Rd
+++ b/man/code_chunk.Rd
@@ -31,7 +31,7 @@ bodies for \code{\link[=use_rmarkdown]{use_rmarkdown()}}.
 setup_chunk()
 
 code_chunk({
-  yml() \%>\%
+  yml() %>%
     yml_output(pdf_document())
 }, chunk_name = "yml_example")
 }

--- a/man/draw_yml_tree.Rd
+++ b/man/draw_yml_tree.Rd
@@ -8,7 +8,7 @@ draw_yml_tree(.yml = last_yml(), indent = "")
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{indent}{a character vector used to indent the tree}
 }
@@ -23,32 +23,42 @@ object to the console.
 # draw the most recently used `yml`
 draw_yml_tree()
 \donttest{
-yml() \%>\%
+yml() %>%
   yml_output(
     pdf_document(keep_tex = TRUE),
     html_document()
-  ) \%>\%
+  ) %>%
     draw_yml_tree()
 }
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{has_field}},
-  \code{\link{read_json}}, \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/gitbook_config.Rd
+++ b/man/gitbook_config.Rd
@@ -4,16 +4,28 @@
 \alias{gitbook_config}
 \title{Configure \code{bookdown::gitbook()} output}
 \usage{
-gitbook_config(toc_collapse = yml_blank(),
-  toc_scroll_highlight = yml_blank(), toc_before = yml_blank(),
-  toc_after = yml_blank(), toolbar_position = yml_blank(),
-  edit = yml_blank(), download = yml_blank(), search = yml_blank(),
-  fontsettings_theme = yml_blank(), fontsettings_family = yml_blank(),
-  fontsettings_size = yml_blank(), sharing_facebook = yml_blank(),
-  sharing_twitter = yml_blank(), sharing_google = yml_blank(),
-  sharing_linkedin = yml_blank(), sharing_weibo = yml_blank(),
-  sharing_instapaper = yml_blank(), sharing_vk = yml_blank(),
-  sharing_all = yml_blank(), ...)
+gitbook_config(
+  toc_collapse = yml_blank(),
+  toc_scroll_highlight = yml_blank(),
+  toc_before = yml_blank(),
+  toc_after = yml_blank(),
+  toolbar_position = yml_blank(),
+  edit = yml_blank(),
+  download = yml_blank(),
+  search = yml_blank(),
+  fontsettings_theme = yml_blank(),
+  fontsettings_family = yml_blank(),
+  fontsettings_size = yml_blank(),
+  sharing_facebook = yml_blank(),
+  sharing_twitter = yml_blank(),
+  sharing_google = yml_blank(),
+  sharing_linkedin = yml_blank(),
+  sharing_weibo = yml_blank(),
+  sharing_instapaper = yml_blank(),
+  sharing_vk = yml_blank(),
+  sharing_all = yml_blank(),
+  ...
+)
 }
 \arguments{
 \item{toc_collapse}{Collapse some items initially when a page is loaded via
@@ -24,7 +36,7 @@ the collapse option. Its possible values are "subsection" (the default),
 scroll the book body? The default is \code{TRUE}.}
 
 \item{toc_before, toc_after}{a character vector of HTML to add more items
-before and after the TOC using the HTML tag \code{<li>}. These items will be
+before and after the TOC using the HTML tag \verb{<li>}. These items will be
 separated from the TOC using a horizontal divider.}
 
 \item{toolbar_position}{The toolbar position: "fixed" or "static." The
@@ -37,7 +49,7 @@ whereas when set to "static" the toolbar will not scroll with the page.}
 character vectors with the length of each vector being 2. When it is a
 character vector, it should be either a vector of filenames or filename
 extensions. When you only provide the filename extensions, the filename is
-derived from the book filename of the configuration file \code{_bookdown.yml}}
+derived from the book filename of the configuration file \verb{_bookdown.yml}}
 
 \item{search}{Include a search bar?}
 
@@ -79,6 +91,7 @@ a list to use in the \code{config} argument of \code{\link[bookdown:gitbook]{boo
 \code{\link[bookdown:gitbook]{bookdown::gitbook()}}, as described in the \href{https://bookdown.org/yihui/bookdown/html.html}{bookdown book}.
 }
 \seealso{
-Other bookdown: \code{\link{yml_bookdown_opts}}
+Other bookdown: 
+\code{\link{yml_bookdown_opts}()}
 }
 \concept{bookdown}

--- a/man/has_field.Rd
+++ b/man/has_field.Rd
@@ -8,7 +8,7 @@ has_field(.yml, field)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{field}{A character vector, the name of the field(s) to check for}
 }
@@ -26,23 +26,33 @@ has_field(yml(), "toc")
 
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{read_json}}, \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/includes2.Rd
+++ b/man/includes2.Rd
@@ -4,8 +4,11 @@
 \alias{includes2}
 \title{Include content within output}
 \usage{
-includes2(in_header = yml_blank(), before_body = yml_blank(),
-  after_body = yml_blank())
+includes2(
+  in_header = yml_blank(),
+  before_body = yml_blank(),
+  after_body = yml_blank()
+)
 }
 \arguments{
 \item{in_header}{One or more files with content to be included in the header
@@ -27,7 +30,7 @@ ymlthis treats NULLs as literal YAML syntax ("null").
 }
 \examples{
 \donttest{
-yml() \%>\%
+yml() %>%
   yml_output(
     pdf_document(includes = includes2(after_body = "footer.tex"))
   )

--- a/man/last_yml.Rd
+++ b/man/last_yml.Rd
@@ -8,7 +8,7 @@ last_yml()
 }
 \description{
 ymlthis stores the most recently printed \code{yml} object; you can use
-\code{last_yml()} to retrieve it to modify, pass to \code{use_*()} functions, and so
+\code{last_yml()} to retrieve it to modify, pass to \verb{use_*()} functions, and so
 on.
 }
 \examples{

--- a/man/pagedown_business_card_template.Rd
+++ b/man/pagedown_business_card_template.Rd
@@ -5,14 +5,26 @@
 \alias{pagedown_person}
 \title{Generate a full YAML template for your pagedown business card}
 \usage{
-pagedown_business_card_template(name = yml_blank(),
-  person = yml_blank(), title = yml_blank(), phone = yml_blank(),
-  email = yml_blank(), url = yml_blank(), address = yml_blank(),
-  logo = yml_blank(), .repeat = yml_blank(),
-  paperwidth = yml_blank(), paperheight = yml_blank(),
-  cardwidth = yml_blank(), cardheight = yml_blank(),
-  cols = yml_blank(), rows = yml_blank(), mainfont = yml_blank(),
-  googlefonts = yml_blank(), ...)
+pagedown_business_card_template(
+  name = yml_blank(),
+  person = yml_blank(),
+  title = yml_blank(),
+  phone = yml_blank(),
+  email = yml_blank(),
+  url = yml_blank(),
+  address = yml_blank(),
+  logo = yml_blank(),
+  .repeat = yml_blank(),
+  paperwidth = yml_blank(),
+  paperheight = yml_blank(),
+  cardwidth = yml_blank(),
+  cardheight = yml_blank(),
+  cols = yml_blank(),
+  rows = yml_blank(),
+  mainfont = yml_blank(),
+  googlefonts = yml_blank(),
+  ...
+)
 
 pagedown_person(...)
 }
@@ -37,7 +49,7 @@ Use \code{pagedown_person()} to do so or manually provide them using \code{list(
 \item{logo}{A path to a logo file}
 
 \item{.repeat}{The number of cards to repeat. Note that the actual YAML field
-is \code{repeat}.}
+is \verb{repeat}.}
 
 \item{paperwidth}{The paper width}
 
@@ -117,6 +129,7 @@ pagedown_business_card_template(
 \seealso{
 \code{\link[=use_rmarkdown]{use_rmarkdown()}}
 
-Other pagedown: \code{\link{yml_pagedown_opts}}
+Other pagedown: 
+\code{\link{yml_pagedown_opts}()}
 }
 \concept{pagedown}

--- a/man/pkgdown_template.Rd
+++ b/man/pkgdown_template.Rd
@@ -13,18 +13,18 @@ pkgdown_template(path = ".")
 a \code{yml} object
 }
 \description{
-pkgdown includes three helpful \code{pkgdown::template_*()} functions to generate
-the navbar, reference, and article YAML for the \code{_pkgdown.yml} file.
+pkgdown includes three helpful \verb{pkgdown::template_*()} functions to generate
+the navbar, reference, and article YAML for the \verb{_pkgdown.yml} file.
 \code{pkgdown_template()} is a wrapper function that runs all three, combines
 them, and converts them to a \code{yml} object. You may also pass
-\code{pkgdown::template_*()} functions to \code{as_yml()} to convert the individual
+\verb{pkgdown::template_*()} functions to \code{as_yml()} to convert the individual
 sections. \code{pkgdown_template()} is particularly useful with
-\code{use_pkgdown_yml()} to write directly to the \code{_pkgdown.yml} file.
+\code{use_pkgdown_yml()} to write directly to the \verb{_pkgdown.yml} file.
 }
 \examples{
 \donttest{
 # requires this to be a package directory
-pkgdown_template() \%>\%
+pkgdown_template() %>%
   use_pkgdown_yml()
 }
 
@@ -32,6 +32,7 @@ pkgdown_template() \%>\%
 \seealso{
 \code{\link[=use_pkgdown_yml]{use_pkgdown_yml()}}
 
-Other pkgdown: \code{\link{yml_pkgdown}}
+Other pkgdown: 
+\code{\link{yml_pkgdown}()}
 }
 \concept{pkgdown}

--- a/man/read_json.Rd
+++ b/man/read_json.Rd
@@ -11,17 +11,29 @@ read_json(path)
 
 read_toml(path)
 
-write_as_json(.yml = NULL, path = NULL, out = NULL,
-  build_ignore = FALSE, git_ignore = FALSE, quiet = FALSE)
+write_as_json(
+  .yml = NULL,
+  path = NULL,
+  out = NULL,
+  build_ignore = FALSE,
+  git_ignore = FALSE,
+  quiet = FALSE
+)
 
-write_as_toml(.yml = NULL, path = NULL, out = NULL,
-  build_ignore = FALSE, git_ignore = FALSE, quiet = FALSE)
+write_as_toml(
+  .yml = NULL,
+  path = NULL,
+  out = NULL,
+  build_ignore = FALSE,
+  git_ignore = FALSE,
+  quiet = FALSE
+)
 }
 \arguments{
 \item{path}{a path to a JSON or TOML file}
 
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{out}{The path to write out to. If \code{NULL}, will write to the \code{path} but
 change the file extension to \code{.toml} or \code{.json}.}
@@ -37,30 +49,40 @@ file?}
 a \code{yml} object (if reading) or the path (if writing)
 }
 \description{
-Read JSON and TOML files in as \code{yml} objects with \code{read_*()}. Write \code{yml}
-objects out as JSON and YAML files with \code{write_as_*()}. You can also provide
-\code{write_as_*()} a path to an existing \code{.yml} file to translate to JSON or
+Read JSON and TOML files in as \code{yml} objects with \verb{read_*()}. Write \code{yml}
+objects out as JSON and YAML files with \verb{write_as_*()}. You can also provide
+\verb{write_as_*()} a path to an existing \code{.yml} file to translate to JSON or
 TOML. These functions rely on Hugo and blogdown, so you must have blogdown
 installed.
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/use_file_yml.Rd
+++ b/man/use_file_yml.Rd
@@ -9,27 +9,57 @@
 \alias{use_bookdown_yml}
 \title{Write YAML to file}
 \usage{
-use_yml_file(.yml = NULL, path, build_ignore = FALSE,
-  git_ignore = FALSE, quiet = FALSE)
+use_yml_file(
+  .yml = NULL,
+  path,
+  build_ignore = FALSE,
+  git_ignore = FALSE,
+  quiet = FALSE
+)
 
-use_output_yml(.yml = NULL, path = ".", build_ignore = FALSE,
-  git_ignore = FALSE, quiet = FALSE)
+use_output_yml(
+  .yml = NULL,
+  path = ".",
+  build_ignore = FALSE,
+  git_ignore = FALSE,
+  quiet = FALSE
+)
 
-use_site_yml(.yml = NULL, path = ".", build_ignore = FALSE,
-  git_ignore = FALSE, quiet = FALSE)
+use_site_yml(
+  .yml = NULL,
+  path = ".",
+  build_ignore = FALSE,
+  git_ignore = FALSE,
+  quiet = FALSE
+)
 
-use_navbar_yml(.yml = NULL, path = ".", build_ignore = FALSE,
-  git_ignore = FALSE, quiet = FALSE)
+use_navbar_yml(
+  .yml = NULL,
+  path = ".",
+  build_ignore = FALSE,
+  git_ignore = FALSE,
+  quiet = FALSE
+)
 
-use_pkgdown_yml(.yml = NULL, path = ".", build_ignore = TRUE,
-  git_ignore = FALSE, quiet = FALSE)
+use_pkgdown_yml(
+  .yml = NULL,
+  path = ".",
+  build_ignore = TRUE,
+  git_ignore = FALSE,
+  quiet = FALSE
+)
 
-use_bookdown_yml(.yml = NULL, path = ".", build_ignore = FALSE,
-  git_ignore = FALSE, quiet = FALSE)
+use_bookdown_yml(
+  .yml = NULL,
+  path = ".",
+  build_ignore = FALSE,
+  git_ignore = FALSE,
+  quiet = FALSE
+)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{path}{a file path to write the file to}
 
@@ -42,16 +72,16 @@ file?}
 }
 \description{
 Write \code{yml} objects to a file. \code{use_yml_file()} writes to any given file
-name. \code{use_output_yml()} creates file \code{_output.yml}, which can be used by
+name. \code{use_output_yml()} creates file \verb{_output.yml}, which can be used by
 multiple R Markdown documents. All documents located in the same directory as
-\code{_output.yml} will inherit its output options. Options defined within
-document YAML headers will override those specified in \code{_output.yml}. Note
+\verb{_output.yml} will inherit its output options. Options defined within
+document YAML headers will override those specified in \verb{_output.yml}. Note
 that \code{use_output_yml()} plucks the output field from \code{yml}; any other YAML
-top-level fields will be ignored. \code{use_site_yml} creates \code{_site.yml} for use
+top-level fields will be ignored. \code{use_site_yml} creates \verb{_site.yml} for use
 with R Markdown websites and third-party tools like the distill package (see
 \href{https://bookdown.org/yihui/rmarkdown/rmarkdown-site.html#}{the R Markdown book for more}).
 \code{use_navbar_yml} is a special type of site YAML that only specifies the
-navbar in \code{_navbar.yml} \code{use_pkgdown_yml()} and \code{use_bookdown_yml()} write
+navbar in \verb{_navbar.yml} \code{use_pkgdown_yml()} and \code{use_bookdown_yml()} write
 YAML files specific to those packages; see the
 \href{https://pkgdown.r-lib.org/articles/pkgdown.html}{pkgdown} and
 \href{https://bookdown.org/yihui/bookdown/configuration.html}{blogdown}
@@ -69,23 +99,33 @@ yml_bookdown_opts yml_bookdown_site yml_pkgdown yml_pkgdown_articles
 yml_pkgdown_docsearch yml_pkgdown_figures yml_pkgdown_news
 yml_pkgdown_reference
 
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/use_yml.Rd
+++ b/man/use_yml.Rd
@@ -8,17 +8,31 @@
 \usage{
 use_yml(.yml = last_yml())
 
-use_rmarkdown(.yml = last_yml(), path, template = NULL,
-  include_yaml = TRUE, include_body = TRUE, body = NULL,
-  quiet = FALSE, open_doc = interactive())
+use_rmarkdown(
+  .yml = last_yml(),
+  path,
+  template = NULL,
+  include_yaml = TRUE,
+  include_body = TRUE,
+  body = NULL,
+  quiet = FALSE,
+  open_doc = interactive()
+)
 
-use_index_rmd(.yml = last_yml(), path, template = NULL,
-  include_yaml = TRUE, include_body = TRUE, body = NULL,
-  quiet = FALSE, open_doc = interactive())
+use_index_rmd(
+  .yml = last_yml(),
+  path,
+  template = NULL,
+  include_yaml = TRUE,
+  include_body = TRUE,
+  body = NULL,
+  quiet = FALSE,
+  open_doc = interactive()
+)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{path}{A file path to write R Markdown file to}
 
@@ -60,23 +74,33 @@ writes to a file called \code{index.Rmd}. By default, \code{use_yml()} and
 \seealso{
 \code{\link[=code_chunk]{code_chunk()}} \code{\link[=setup_chunk]{setup_chunk()}}
 
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/use_yml_defaults.Rd
+++ b/man/use_yml_defaults.Rd
@@ -17,7 +17,7 @@ get_rmd_defaults()
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{x}{a character vector to use as the body text in \code{\link[=use_rmarkdown]{use_rmarkdown()}}.}
 }
@@ -34,23 +34,33 @@ body text of the created R Markdown file.
 \seealso{
 \code{\link[=yml]{yml()}} \code{\link[=get_yml_defaults]{get_yml_defaults()}}
 
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/yml.Rd
+++ b/man/yml.Rd
@@ -31,13 +31,13 @@ fields, respectively. If you've set default YAML in
 \code{getOption("ymlthis.default_option")} (see \code{\link[=use_yml_defaults]{use_yml_defaults()}}), \code{yml()}
 will also use include those fields by default. \code{yml_empty()} is a wrapper
 that doesn't use any of these default YAML fields. \code{yml()} and all
-related\code{yml_*()} functions validate that the results are indeed valid YAML
+related\verb{yml_*()} functions validate that the results are indeed valid YAML
 syntax, although not every function is able to check that the input fields
 are valid for the setting they are used in.
 }
 \details{
 \code{.yml} accepts a character vector of YAML, such as "author: Hadley Wickham",
-an object returned by ymlthis functions that start with \code{yml_*()}, or a
+an object returned by ymlthis functions that start with \verb{yml_*()}, or a
 \code{list} object (e.g. \code{list(author = "Hadley Wickham")}). \code{.yml} objects are
 processed with \code{\link[=as_yml]{as_yml()}}, a wrapper around \code{\link[yaml:yaml.load]{yaml::yaml.load()}}. See that
 function for more details.
@@ -55,18 +55,18 @@ yml(date = FALSE)
     c("data cleaning", "data tidying", "relational databases", "R")
   )
 \donttest{
-yml() \%>\%
+yml() %>%
   yml_author(
     c("Yihui Xie", "Hadley Wickham"),
     affiliation = rep("RStudio", 2)
-  ) \%>\%
-  yml_date("07/04/2019") \%>\%
+  ) %>%
+  yml_date("07/04/2019") %>%
   yml_output(
     pdf_document(
     keep_tex = TRUE,
     includes = includes2(after_body = "footer.tex")
    )
-  ) \%>\%
+  ) %>%
   yml_latex_opts(biblio_style = "apalike")
 }
 }

--- a/man/yml_author.Rd
+++ b/man/yml_author.Rd
@@ -38,7 +38,7 @@ yml_toplevel(.yml, ...)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{name}{A character vector, name of the author(s)}
 
@@ -107,7 +107,7 @@ YAML; it checks for duplicate fields but is unable to validate the input
 beyond that it is valid YAML syntax. Some R Markdown templates allow for
 additional variations of the YAML here. For instance, the distill package
 adds \code{url} and \code{affiliation_url} to the \code{author} field (see
-\link{yml_distill_author}, which wraps \link{yml_author}). Several \code{yml_*()} functions
+\link{yml_distill_author}, which wraps \link{yml_author}). Several \verb{yml_*()} functions
 also contain \code{...} which allow for these unique fields.
 }
 \examples{
@@ -125,23 +125,33 @@ yml_empty() \%>\%
 
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/yml_blogdown_opts.Rd
+++ b/man/yml_blogdown_opts.Rd
@@ -4,19 +4,36 @@
 \alias{yml_blogdown_opts}
 \title{Set Top-level YAML options for blogdown}
 \usage{
-yml_blogdown_opts(.yml, draft = yml_blank(), publishdate = yml_blank(),
-  weight = yml_blank(), slug = yml_blank(), aliases = yml_blank(),
-  audio = yml_blank(), date = yml_blank(), description = yml_blank(),
-  expiration_date = yml_blank(), headless = yml_blank(),
-  images = yml_blank(), keywords = yml_blank(), layout = yml_blank(),
-  lastmod = yml_blank(), link_title = yml_blank(),
-  resources = yml_blank(), series = yml_blank(),
-  summary = yml_blank(), title = yml_blank(), type = yml_blank(),
-  url = yml_blank(), videos = yml_blank(), ...)
+yml_blogdown_opts(
+  .yml,
+  draft = yml_blank(),
+  publishdate = yml_blank(),
+  weight = yml_blank(),
+  slug = yml_blank(),
+  aliases = yml_blank(),
+  audio = yml_blank(),
+  date = yml_blank(),
+  description = yml_blank(),
+  expiration_date = yml_blank(),
+  headless = yml_blank(),
+  images = yml_blank(),
+  keywords = yml_blank(),
+  layout = yml_blank(),
+  lastmod = yml_blank(),
+  link_title = yml_blank(),
+  resources = yml_blank(),
+  series = yml_blank(),
+  summary = yml_blank(),
+  title = yml_blank(),
+  type = yml_blank(),
+  url = yml_blank(),
+  videos = yml_blank(),
+  ...
+)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{draft}{Logical. Set post as a draft? Draft posts will not be rendered
 if the site is built via \code{blogdown::build_site()} or
@@ -111,23 +128,33 @@ yml() \%>\%
   )
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/yml_bookdown_opts.Rd
+++ b/man/yml_bookdown_opts.Rd
@@ -5,19 +5,26 @@
 \alias{yml_bookdown_site}
 \title{Set Top-level YAML options for bookdown}
 \usage{
-yml_bookdown_opts(.yml, book_filename = yml_blank(),
+yml_bookdown_opts(
+  .yml,
+  book_filename = yml_blank(),
   delete_merged_file = yml_blank(),
   before_chapter_script = yml_blank(),
-  after_chapter_script = yml_blank(), edit = yml_blank(),
-  history = yml_blank(), rmd_files = yml_blank(),
-  rmd_subdir = yml_blank(), output_dir = yml_blank(),
-  clean = yml_blank(), ...)
+  after_chapter_script = yml_blank(),
+  edit = yml_blank(),
+  history = yml_blank(),
+  rmd_files = yml_blank(),
+  rmd_subdir = yml_blank(),
+  output_dir = yml_blank(),
+  clean = yml_blank(),
+  ...
+)
 
 yml_bookdown_site(.yml)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{book_filename}{A character vector, the filename of the main \code{.Rmd}
 file, the \code{.Rmd} file that is created by merging all chapters. By default,
@@ -30,7 +37,7 @@ or more R scripts to be executed before or after each chapter}
 
 \item{edit}{A URL that collaborators can click to edit the \code{.Rmd} source
 document of the current page, usually a link to a GitHub repository. This
-link should have \code{\%s} where the actual \code{.Rmd} filename for each page will
+link should have \verb{\%s} where the actual \code{.Rmd} filename for each page will
 go.}
 
 \item{history}{Similar to \code{edit}, a link to the edit/commit history of the
@@ -60,11 +67,11 @@ a \code{yml} object
 }
 \description{
 bookdown uses YAML in three main places, as described in the \href{https://bookdown.org/yihui/rmarkdown/bookdown-project.html}{bookdown book}:
-\code{index.Rmd}, \code{_output.yml}, and \code{_bookdown.yml}. \code{index.Rmd} can take most
-YAML. \code{_output.yml} is intended for output-related YAML, such as that
-produced by \code{yml() \%>\% yml_output(bookdown::pdf_book())}. \code{_bookdown.yml} is
+\code{index.Rmd}, \verb{_output.yml}, and \verb{_bookdown.yml}. \code{index.Rmd} can take most
+YAML. \verb{_output.yml} is intended for output-related YAML, such as that
+produced by \code{yml() \%>\% yml_output(bookdown::pdf_book())}. \verb{_bookdown.yml} is
 intended for configuring the build of the book. Pass the results of the
-\code{yml_*()} functions to \code{use_index_rmd()}, \code{use_bookdown_yml()},
+\verb{yml_*()} functions to \code{use_index_rmd()}, \code{use_bookdown_yml()},
 \code{use_output_yml()} to write them to these files. \code{yml_bookdown_site()} adds
 the \code{site: "bookdown::bookdown_site"} to the YAML metadata.
 }
@@ -108,7 +115,7 @@ x
 
 
 \donttest{
-output_yml <- yml_empty() \%>\%
+output_yml <- yml_empty() %>%
   yml_output(
     bookdown::gitbook(
       lib_dir = "assets",
@@ -126,26 +133,37 @@ output_yml
 \seealso{
 \code{\link[=use_index_rmd]{use_index_rmd()}} \code{\link[=use_bookdown_yml]{use_bookdown_yml()}} \code{\link[=use_output_yml]{use_output_yml()}}
 
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 
-Other bookdown: \code{\link{gitbook_config}}
+Other bookdown: 
+\code{\link{gitbook_config}()}
 }
 \concept{bookdown}
 \concept{yml}

--- a/man/yml_citations.Rd
+++ b/man/yml_citations.Rd
@@ -4,15 +4,21 @@
 \alias{yml_citations}
 \title{Set citation-related YAML options}
 \usage{
-yml_citations(.yml, bibliography = yml_blank(),
-  biblio_style = yml_blank(), biblio_title = yml_blank(),
-  csl = yml_blank(), citation_abbreviations = yml_blank(),
-  link_citations = yml_blank(), nocite = yml_blank(),
-  suppress_bibliography = yml_blank())
+yml_citations(
+  .yml,
+  bibliography = yml_blank(),
+  biblio_style = yml_blank(),
+  biblio_title = yml_blank(),
+  csl = yml_blank(),
+  citation_abbreviations = yml_blank(),
+  link_citations = yml_blank(),
+  nocite = yml_blank(),
+  suppress_bibliography = yml_blank()
+)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{bibliography}{a path to a bibliography file, such as a .bib file}
 
@@ -60,27 +66,38 @@ yml() \%>\%
 
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 
-Other citations: \code{\link{bib2yml}},
-  \code{\link{yml_reference}}
+Other citations: 
+\code{\link{bib2yml}()},
+\code{\link{yml_reference}()}
 }
 \concept{citations}
 \concept{yml}

--- a/man/yml_clean.Rd
+++ b/man/yml_clean.Rd
@@ -8,7 +8,7 @@ yml_clean(.yml, clean)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{clean}{Logical. Remove intermediate files that are created while making
 the R Markdown document?}
@@ -30,29 +30,40 @@ yml() \%>\%
 
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 
-Other R Markdown: \code{\link{yml_params}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_vignette}}
+Other R Markdown: 
+\code{\link{yml_params}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_vignette}()}
 }
 \concept{R Markdown}
 \concept{yml}

--- a/man/yml_distill_opts.Rd
+++ b/man/yml_distill_opts.Rd
@@ -8,32 +8,56 @@
 \alias{distill_resources}
 \title{Set Top-level YAML options for distill}
 \usage{
-yml_distill_opts(.yml, draft = yml_blank(), slug = yml_blank(),
-  categories = yml_blank(), listing = yml_blank(),
-  collection = yml_blank(), citation_url = yml_blank(),
-  preview = yml_blank(), repository_url = yml_blank(),
-  base_url = yml_blank(), compare_updates_url = yml_blank(),
-  creative_commons = yml_blank(), twitter_site = yml_blank(),
-  twitter_creator = yml_blank(), journal_title = yml_blank(),
-  journal_issn = yml_blank(), journal_publisher = yml_blank(),
-  volume = yml_blank(), issue = yml_blank(), doi = yml_blank(),
-  resources = yml_blank(), ...)
+yml_distill_opts(
+  .yml,
+  draft = yml_blank(),
+  slug = yml_blank(),
+  categories = yml_blank(),
+  listing = yml_blank(),
+  collection = yml_blank(),
+  citation_url = yml_blank(),
+  preview = yml_blank(),
+  repository_url = yml_blank(),
+  base_url = yml_blank(),
+  compare_updates_url = yml_blank(),
+  creative_commons = yml_blank(),
+  twitter_site = yml_blank(),
+  twitter_creator = yml_blank(),
+  journal_title = yml_blank(),
+  journal_issn = yml_blank(),
+  journal_publisher = yml_blank(),
+  volume = yml_blank(),
+  issue = yml_blank(),
+  doi = yml_blank(),
+  resources = yml_blank(),
+  ...
+)
 
-yml_distill_author(.yml, name = yml_blank(), url = yml_blank(),
-  affiliation = yml_blank(), affiliation_url = yml_blank())
+yml_distill_author(
+  .yml,
+  name = yml_blank(),
+  url = yml_blank(),
+  affiliation = yml_blank(),
+  affiliation_url = yml_blank()
+)
 
 distill_listing(listing_name = "posts", slugs = NULL)
 
-distill_collection(collection_name = "post",
-  feed_items_max = yml_blank(), disqus_name = yml_blank(),
-  disqus_hidden = yml_blank(), share = yml_blank(),
-  citations = yml_blank(), subscribe = yml_blank())
+distill_collection(
+  collection_name = "post",
+  feed_items_max = yml_blank(),
+  disqus_name = yml_blank(),
+  disqus_hidden = yml_blank(),
+  share = yml_blank(),
+  citations = yml_blank(),
+  subscribe = yml_blank()
+)
 
 distill_resources(include = yml_blank(), exclude = yml_blank())
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{draft}{Logical. Set the post to be a draft? Draft posts won't be
 published.}
@@ -126,7 +150,7 @@ this is \code{FALSE} so as not to obscure the bibliography and other appendices.
 "facebook", "google-plus", and "pinterest". (\code{base_url} field is required
 in order to use sharing links)}
 
-\item{citations}{Logical. If your \code{_site.yml} file provides a \code{base_url}
+\item{citations}{Logical. If your \verb{_site.yml} file provides a \code{base_url}
 field, an article citation appendix and related metadata will be included
 automatically within all published posts. Set to \code{FALSE} to disable this
 behavior.}
@@ -152,7 +176,7 @@ to, including an optional vector of other posts to list with it;
 specify such pages. distill uses the same approach to navbars as R Markdown.
 \code{\link[=yml_navbar]{yml_navbar()}} and friends will help you write the YAML for that. YAML
 specifying the site build, like the output field and navbars, can also be
-placed in \code{_site.yml}; see \code{\link[=yml_site_opts]{yml_site_opts()}} for further R Markdown website
+placed in \verb{_site.yml}; see \code{\link[=yml_site_opts]{yml_site_opts()}} for further R Markdown website
 build options and \code{\link[=use_site_yml]{use_site_yml()}} for creating that file based on a \code{yml}
 object. distill's YAML options are discussed in greater detail in the
 \href{https://rstudio.github.io/distill}{articles on the distill website}.
@@ -189,27 +213,38 @@ yml_empty() \%>\%
 \seealso{
 \code{\link[=use_site_yml]{use_site_yml()}} \code{\link[=use_rmarkdown]{use_rmarkdown()}}
 
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 
-Other websites: \code{\link{yml_pkgdown}},
-  \code{\link{yml_site_opts}}
+Other websites: 
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_site_opts}()}
 }
 \concept{distill}
 \concept{websites}

--- a/man/yml_latex_opts.Rd
+++ b/man/yml_latex_opts.Rd
@@ -4,33 +4,58 @@
 \alias{yml_latex_opts}
 \title{Set LaTeX YAML options for PDF output}
 \usage{
-yml_latex_opts(.yml, block_headings = yml_blank(),
-  classoption = yml_blank(), documentclass = yml_blank(),
-  geometry = yml_blank(), indent = yml_blank(),
-  linestretch = yml_blank(), margin_left = yml_blank(),
-  margin_right = yml_blank(), margin_top = yml_blank(),
-  margin_bottom = yml_blank(), pagestyle = yml_blank(),
-  papersize = yml_blank(), secnumdepth = yml_blank(),
-  fontenc = yml_blank(), fontfamily = yml_blank(),
-  fontfamilyoptions = yml_blank(), fontsize = yml_blank(),
-  mainfont = yml_blank(), sansfont = yml_blank(),
-  monofont = yml_blank(), mathfont = yml_blank(),
-  CJKmainfont = yml_blank(), mainfontoptions = yml_blank(),
-  sansfontoptions = yml_blank(), monofontoptions = yml_blank(),
-  mathfontoptions = yml_blank(), CJKoptions = yml_blank(),
-  microtypeoptions = yml_blank(), colorlinks = yml_blank(),
-  linkcolor = yml_blank(), filecolor = yml_blank(),
-  citecolor = yml_blank(), urlcolor = yml_blank(),
-  toccolor = yml_blank(), links_as_notes = yml_blank(),
-  lof = yml_blank(), lot = yml_blank(), thanks = yml_blank(),
-  toc = yml_blank(), toc_depth = yml_blank(),
-  biblatexoptions = yml_blank(), biblio_style = yml_blank(),
-  biblio_title = yml_blank(), bibliography = yml_blank(),
-  natbiboptions = yml_blank())
+yml_latex_opts(
+  .yml,
+  block_headings = yml_blank(),
+  classoption = yml_blank(),
+  documentclass = yml_blank(),
+  geometry = yml_blank(),
+  indent = yml_blank(),
+  linestretch = yml_blank(),
+  margin_left = yml_blank(),
+  margin_right = yml_blank(),
+  margin_top = yml_blank(),
+  margin_bottom = yml_blank(),
+  pagestyle = yml_blank(),
+  papersize = yml_blank(),
+  secnumdepth = yml_blank(),
+  fontenc = yml_blank(),
+  fontfamily = yml_blank(),
+  fontfamilyoptions = yml_blank(),
+  fontsize = yml_blank(),
+  mainfont = yml_blank(),
+  sansfont = yml_blank(),
+  monofont = yml_blank(),
+  mathfont = yml_blank(),
+  CJKmainfont = yml_blank(),
+  mainfontoptions = yml_blank(),
+  sansfontoptions = yml_blank(),
+  monofontoptions = yml_blank(),
+  mathfontoptions = yml_blank(),
+  CJKoptions = yml_blank(),
+  microtypeoptions = yml_blank(),
+  colorlinks = yml_blank(),
+  linkcolor = yml_blank(),
+  filecolor = yml_blank(),
+  citecolor = yml_blank(),
+  urlcolor = yml_blank(),
+  toccolor = yml_blank(),
+  links_as_notes = yml_blank(),
+  lof = yml_blank(),
+  lot = yml_blank(),
+  thanks = yml_blank(),
+  toc = yml_blank(),
+  toc_depth = yml_blank(),
+  biblatexoptions = yml_blank(),
+  biblio_style = yml_blank(),
+  biblio_title = yml_blank(),
+  bibliography = yml_blank(),
+  natbiboptions = yml_blank()
+)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{block_headings}{make paragraph and subparagraph (fourth- and
 fifth-level headings, or fifth- and sixth-level with book classes)
@@ -54,7 +79,7 @@ paragraphs.}
 
 \item{margin_left, margin_right, margin_top, margin_bottom}{sets margins if
 \code{geometry} is not used, otherwise \code{geometry} overrides these. Note that the
-actual YAML fields use \code{-} instead of \code{_}, e.g. \code{margin-left}.}
+actual YAML fields use \verb{-} instead of \verb{_}, e.g. \code{margin-left}.}
 
 \item{pagestyle}{control the \code{pagestyle} LaTeX command: the default article
 class supports "plain" (default), "empty" (no running heads or page
@@ -140,8 +165,8 @@ these descriptions were derived), as when making a PDF document with
 }
 \examples{
 \donttest{
-yml() \%>\%
-   yml_output(pdf_document()) \%>\%
+yml() %>%
+   yml_output(pdf_document()) %>%
    yml_latex_opts(
      fontfamily = "Fira Sans Thin",
      fontsize = "11pt",
@@ -150,23 +175,33 @@ yml() \%>\%
 }
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/yml_output.Rd
+++ b/man/yml_output.Rd
@@ -8,10 +8,10 @@ yml_output(.yml, ...)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{...}{valid R code calling functions that return objects of class
-\code{rmarkdown_output_format}, such as the \code{*_document()} functions in
+\code{rmarkdown_output_format}, such as the \verb{*_document()} functions in
 rmarkdown.}
 }
 \value{
@@ -29,10 +29,10 @@ function using \code{?pdf_document}.
 }
 \examples{
 \donttest{
-yml() \%>\%
+yml() %>%
   yml_output(html_document())
 
-yml() \%>\%
+yml() %>%
   yml_output(
     pdf_document(keep_tex = TRUE, includes = includes2(after_body = "footer.tex")),
     bookdown::html_document2()
@@ -40,24 +40,33 @@ yml() \%>\%
 }
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/yml_pagedown_opts.Rd
+++ b/man/yml_pagedown_opts.Rd
@@ -4,14 +4,20 @@
 \alias{yml_pagedown_opts}
 \title{Top-level YAML options for pagedown}
 \usage{
-yml_pagedown_opts(.yml, toc = yml_blank(), toc_title = yml_blank(),
-  lot = yml_blank(), lot_title = yml_blank(),
-  chapter_name = yml_blank(), links_to_footnotes = yml_blank(),
-  paged_footnotes = yml_blank())
+yml_pagedown_opts(
+  .yml,
+  toc = yml_blank(),
+  toc_title = yml_blank(),
+  lot = yml_blank(),
+  lot_title = yml_blank(),
+  chapter_name = yml_blank(),
+  links_to_footnotes = yml_blank(),
+  paged_footnotes = yml_blank()
+)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{toc}{Logical. Use a table of contents?}
 
@@ -55,26 +61,37 @@ yml() \%>\%
 
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 
-Other pagedown: \code{\link{pagedown_business_card_template}}
+Other pagedown: 
+\code{\link{pagedown_business_card_template}()}
 }
 \concept{pagedown}
 \concept{yml}

--- a/man/yml_params.Rd
+++ b/man/yml_params.Rd
@@ -20,35 +20,79 @@ shiny_params(.shiny)
 
 shiny_checkbox(label, value = FALSE, width = NULL)
 
-shiny_numeric(label, value, min = NA, max = NA, step = NA,
-  width = NULL)
+shiny_numeric(label, value, min = NA, max = NA, step = NA, width = NULL)
 
-shiny_slider(label, min, max, value, step = NULL, round = FALSE,
-  format = NULL, locale = NULL, ticks = TRUE, animate = FALSE,
-  width = NULL, sep = ",", pre = NULL, post = NULL,
-  timeFormat = NULL, timezone = NULL, dragRange = TRUE)
+shiny_slider(
+  label,
+  min,
+  max,
+  value,
+  step = NULL,
+  round = FALSE,
+  format = NULL,
+  locale = NULL,
+  ticks = TRUE,
+  animate = FALSE,
+  width = NULL,
+  sep = ",",
+  pre = NULL,
+  post = NULL,
+  timeFormat = NULL,
+  timezone = NULL,
+  dragRange = TRUE
+)
 
-shiny_date(label, value = NULL, min = NULL, max = NULL,
-  format = "yyyy-mm-dd", startview = "month", weekstart = 0,
-  language = "en", width = NULL, autoclose = TRUE,
-  datesdisabled = NULL, daysofweekdisabled = NULL)
+shiny_date(
+  label,
+  value = NULL,
+  min = NULL,
+  max = NULL,
+  format = "yyyy-mm-dd",
+  startview = "month",
+  weekstart = 0,
+  language = "en",
+  width = NULL,
+  autoclose = TRUE,
+  datesdisabled = NULL,
+  daysofweekdisabled = NULL
+)
 
 shiny_text(label, value = "", width = NULL, placeholder = NULL)
 
-shiny_file(label, multiple = FALSE, accept = NULL, width = NULL,
-  buttonLabel = "Browse...", placeholder = "No file selected")
+shiny_file(
+  label,
+  multiple = FALSE,
+  accept = NULL,
+  width = NULL,
+  buttonLabel = "Browse...",
+  placeholder = "No file selected"
+)
 
-shiny_radio(label, choices = NULL, selected = NULL, inline = FALSE,
-  width = NULL, choiceNames = NULL, choiceValues = NULL)
+shiny_radio(
+  label,
+  choices = NULL,
+  selected = NULL,
+  inline = FALSE,
+  width = NULL,
+  choiceNames = NULL,
+  choiceValues = NULL
+)
 
-shiny_select(label, choices, selected = NULL, multiple = FALSE,
-  selectize = TRUE, width = NULL, size = NULL)
+shiny_select(
+  label,
+  choices,
+  selected = NULL,
+  multiple = FALSE,
+  selectize = TRUE,
+  width = NULL,
+  size = NULL
+)
 
 shiny_password(label, value = "", width = NULL, placeholder = NULL)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{...}{additional named R objects, such as characters or lists, to
 transform into YAML}
@@ -59,7 +103,7 @@ transform into YAML}
 
 \item{value}{Initial value (\code{TRUE} or \code{FALSE}).}
 
-\item{width}{The width of the input, e.g. '400px', or '100%'; see
+\item{width}{The width of the input, e.g. '400px', or '100\%'; see
 \code{\link[shiny:validateCssUnit]{shiny::validateCssUnit()}}}
 
 \item{min}{Minimum allowed value}
@@ -95,7 +139,7 @@ using \code{\link[shiny:animationOptions]{shiny::animationOptions()}}}
 format string, to be passed to the Javascript strftime library. See
 \url{https://github.com/samsonjs/strftime} for more details. The allowed
 format specifications are very similar, but not identical, to those for R's
-\code{\link[base]{strftime}} function. For Dates, the default is \code{"\%F"}
+\code{\link[base:strftime]{base::strftime()}} function. For Dates, the default is \code{"\%F"}
 (like \code{"2015-07-01"}), and for POSIXt, the default is \code{"\%F \%T"}
 (like \code{"2015-07-01 15:32:10"}).}
 
@@ -139,7 +183,7 @@ be entered into the control. Internet Explorer 8 and 9 do not support this
 option.}
 
 \item{multiple}{Whether the user should be allowed to select and upload
-multiple files at once. \bold{Does not work on older browsers, including
+multiple files at once. \strong{Does not work on older browsers, including
 Internet Explorer 9 and earlier.}}
 
 \item{accept}{A character vector of MIME types; gives the browser a hint of
@@ -183,8 +227,8 @@ Examples.}
 
 \item{size}{Number of items to show in the selection box; a larger number
 will result in a taller box. Not compatible with \code{selectize=TRUE}.
-Normally, when \code{multiple=FALSE}, a select input will be a drop-down
-list, but when \code{size} is set, it will be a box instead.}
+Normally, when \code{multiple=FALSE}, a select input will be a drop-down list,
+but when \code{size} is set, it will be a box instead.}
 }
 \value{
 a \code{yml} object
@@ -199,10 +243,10 @@ change the YAML, use the \code{params} argument in \code{rmarkdown::render()}, o
 with parameters, which launches a Shiny app to select values for each.
 \code{yml_params()} accepts any number of named R objects to set as YAML fields.
 You can also pass arguments to the underlying Shiny functions using YAML. To
-set a shiny component, use the \code{shiny_*()} helper functions. \code{shiny_params()}
+set a shiny component, use the \verb{shiny_*()} helper functions. \code{shiny_params()}
 captures a Shiny output function and transforms it to YAML. However, R
 Markdown supports only a limited number of components; each of these is
-included as a function starting with \code{shiny_*()}, e.g. \code{shiny_checkbox()}
+included as a function starting with \verb{shiny_*()}, e.g. \code{shiny_checkbox()}
 }
 \examples{
 
@@ -218,31 +262,43 @@ yml() \%>\%
 \seealso{
 \code{\link[=yml_params_code]{yml_params_code()}}
 
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_pkgdown}}, \code{\link{yml_reference}},
-  \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 
-Other R Markdown: \code{\link{yml_clean}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_vignette}}
+Other R Markdown: 
+\code{\link{yml_clean}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_vignette}()}
 
-Other shiny: \code{\link{yml_runtime}}
+Other shiny: 
+\code{\link{yml_runtime}()}
 }
 \concept{R Markdown}
 \concept{shiny}

--- a/man/yml_pkgdown.Rd
+++ b/man/yml_pkgdown.Rd
@@ -18,47 +18,88 @@
 \usage{
 yml_pkgdown(.yml, as_is = yml_blank(), extension = yml_blank())
 
-yml_pkgdown_opts(.yml, site_title = yml_blank(),
-  destination = yml_blank(), url = yml_blank(),
-  toc_depth = yml_blank())
+yml_pkgdown_opts(
+  .yml,
+  site_title = yml_blank(),
+  destination = yml_blank(),
+  url = yml_blank(),
+  toc_depth = yml_blank()
+)
 
-yml_pkgdown_development(.yml, mode = yml_blank(),
-  dev_destination = yml_blank(), version_label = yml_blank(),
-  version_tooltip = yml_blank())
+yml_pkgdown_development(
+  .yml,
+  mode = yml_blank(),
+  dev_destination = yml_blank(),
+  version_label = yml_blank(),
+  version_tooltip = yml_blank()
+)
 
-yml_pkgdown_template(.yml, bootswatch = yml_blank(),
-  ganalytics = yml_blank(), noindex = yml_blank(),
-  package = yml_blank(), path = yml_blank(), assets = yml_blank(),
-  default_assets = yml_blank())
+yml_pkgdown_template(
+  .yml,
+  bootswatch = yml_blank(),
+  ganalytics = yml_blank(),
+  noindex = yml_blank(),
+  package = yml_blank(),
+  path = yml_blank(),
+  assets = yml_blank(),
+  default_assets = yml_blank()
+)
 
 yml_pkgdown_reference(.yml, ...)
 
-pkgdown_ref(title = yml_blank(), desc = yml_blank(),
-  contents = yml_blank(), exclude = yml_blank(), ...)
+pkgdown_ref(
+  title = yml_blank(),
+  desc = yml_blank(),
+  contents = yml_blank(),
+  exclude = yml_blank(),
+  ...
+)
 
 yml_pkgdown_news(.yml, one_page = yml_blank())
 
 yml_pkgdown_articles(.yml, ...)
 
-pkgdown_article(title = yml_blank(), desc = yml_blank(),
-  contents = yml_blank(), exclude = yml_blank(), ...)
+pkgdown_article(
+  title = yml_blank(),
+  desc = yml_blank(),
+  contents = yml_blank(),
+  exclude = yml_blank(),
+  ...
+)
 
 yml_pkgdown_tutorial(.yml, ...)
 
-pkgdown_tutorial(name = yml_blank(), title = yml_blank(),
-  tutorial_url = yml_blank(), source = yml_blank(), ...)
+pkgdown_tutorial(
+  name = yml_blank(),
+  title = yml_blank(),
+  tutorial_url = yml_blank(),
+  source = yml_blank(),
+  ...
+)
 
-yml_pkgdown_figures(.yml, dev = yml_blank(), dpi = yml_blank(),
-  dev.args = yml_blank(), fig.ext = yml_blank(),
-  fig.width = yml_blank(), fig.height = yml_blank(),
-  fig.retina = yml_blank(), fig.asp = yml_blank(), ...)
+yml_pkgdown_figures(
+  .yml,
+  dev = yml_blank(),
+  dpi = yml_blank(),
+  dev.args = yml_blank(),
+  fig.ext = yml_blank(),
+  fig.width = yml_blank(),
+  fig.height = yml_blank(),
+  fig.retina = yml_blank(),
+  fig.asp = yml_blank(),
+  ...
+)
 
-yml_pkgdown_docsearch(.yml, api_key = yml_blank(),
-  index_name = yml_blank(), doc_url = yml_blank())
+yml_pkgdown_docsearch(
+  .yml,
+  api_key = yml_blank(),
+  index_name = yml_blank(),
+  doc_url = yml_blank()
+)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{as_is}{Logical. Use the \code{output_format} and options that you have
 specified?}
@@ -161,16 +202,16 @@ a \code{yml} object
 }
 \description{
 These functions set YAML for various pkgdown options to be used in
-\code{_pkgdown.yml}. The options are described in greater depth in the \href{https://pkgdown.r-lib.org/articles/pkgdown.html}{pkgdown vignette} and in the help
+\verb{_pkgdown.yml}. The options are described in greater depth in the \href{https://pkgdown.r-lib.org/articles/pkgdown.html}{pkgdown vignette} and in the help
 pages for \code{pkgdown::build_site()}, \code{pkgdown::build_articles()}, \code{pkgdown::build_reference()}, and \code{pkgdown::build_tutorials()}.
 Essentially, they control the build of vignettes and function references.
 pkgdown also uses the same approach to navbars as R Markdown.
 \code{\link[=yml_navbar]{yml_navbar()}} and friends will help you write the YAML for that. A useful
 approach to writing pkgdown YAML might be to use \code{pkgdown_template()} to
 build a template based on your package directory, modify with
-\code{yml_pkgdown_*()} and \code{pkgdown_*()} functions or \code{\link[=yml_replace]{yml_replace()}} and
+\verb{yml_pkgdown_*()} and \verb{pkgdown_*()} functions or \code{\link[=yml_replace]{yml_replace()}} and
 \code{\link[=yml_discard]{yml_discard()}}, then pass the results to \code{\link[=use_pkgdown_yml]{use_pkgdown_yml()}} to write to
-\code{_pkgdown.yml}
+\verb{_pkgdown.yml}
 }
 \examples{
 
@@ -195,30 +236,41 @@ yml_empty() \%>\%
 \seealso{
 \code{\link[=use_pkgdown_yml]{use_pkgdown_yml()}} \code{\link[=yml_navbar]{yml_navbar()}}
 
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_reference}},
-  \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 
-Other pkgdown: \code{\link{pkgdown_template}}
+Other pkgdown: 
+\code{\link{pkgdown_template}()}
 
-Other websites: \code{\link{yml_distill_opts}},
-  \code{\link{yml_site_opts}}
+Other websites: 
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_site_opts}()}
 }
 \concept{pkgdown}
 \concept{websites}

--- a/man/yml_reference.Rd
+++ b/man/yml_reference.Rd
@@ -11,7 +11,7 @@ reference(id = NULL, ...)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{...}{Fields relevant to the citation (e.g. bibtex fields)}
 
@@ -93,36 +93,46 @@ bref <- c(
 )
 \donttest{
 # requires pandoc-citeproc to be installed
-yml() \%>\%
+yml() %>%
   yml_reference(.bibentry = bref)
 
-yml() \%>\%
+yml() %>%
   yml_reference(.bibentry = citation("purrr"))
 }
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 
-Other citations: \code{\link{bib2yml}},
-  \code{\link{yml_citations}}
+Other citations: 
+\code{\link{bib2yml}()},
+\code{\link{yml_citations}()}
 }
 \concept{citations}
 \concept{yml}

--- a/man/yml_replace.Rd
+++ b/man/yml_replace.Rd
@@ -17,7 +17,7 @@ yml_chuck(.yml, ...)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{...}{additional named R objects, such as characters or lists, to
 transform into YAML}
@@ -40,39 +40,48 @@ objects.
 }
 \examples{
 \donttest{
-yml() \%>\%
-  yml_clean(TRUE) \%>\%
-  yml_replace(clean = FALSE) \%>\%
+yml() %>%
+  yml_clean(TRUE) %>%
+  yml_replace(clean = FALSE) %>%
   yml_discard("author")
 
-yml() \%>\%
+yml() %>%
   yml_output(
     pdf_document(),
     html_document()
-  )\%>\%
+  )%>%
   yml_discard(~ length(.x) > 1)
 }
 
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/yml_resource_files.Rd
+++ b/man/yml_resource_files.Rd
@@ -8,7 +8,7 @@ yml_resource_files(.yml, resource_files)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{resource_files}{A path to a file, directory, or a wildcard pattern
 (such as "data/*.csv")}
@@ -28,23 +28,33 @@ yml() \%>\%
   yml_resource_files(c("data/mydata.csv", "images/figure.png"))
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/yml_rsconnect_email.Rd
+++ b/man/yml_rsconnect_email.Rd
@@ -5,19 +5,25 @@
 \alias{yml_output_metadata}
 \title{Set YAML for Scheduled Emails in RStudio Connect}
 \usage{
-yml_rsconnect_email(.yml, rsc_email_subject = yml_blank(),
-  rsc_email_body_html = yml_blank(), rsc_email_body_text = yml_blank(),
-  rsc_email_images = yml_blank(), rsc_output_files = yml_blank(),
+yml_rsconnect_email(
+  .yml,
+  rsc_email_subject = yml_blank(),
+  rsc_email_body_html = yml_blank(),
+  rsc_email_body_text = yml_blank(),
+  rsc_email_images = yml_blank(),
+  rsc_output_files = yml_blank(),
   rsc_email_attachments = yml_blank(),
   rsc_email_suppress_scheduled = yml_blank(),
   rsc_email_suppress_report_attachment = yml_blank(),
-  resource_files = yml_blank(), ...)
+  resource_files = yml_blank(),
+  ...
+)
 
 yml_output_metadata(.yml, ...)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{rsc_email_subject}{The subject of the email. A report without an
 \code{rsc_email_subject} entry uses its published document name.}
@@ -59,7 +65,7 @@ a \code{yml} object
 \description{
 RStudio Connect allows you to schedule emails to send using R Markdown. It
 uses a special type of YAML using the top-level field \code{rmd_output_metadata}
-that tells RStudio Connect about the email output. Several \code{rsc_*} fields
+that tells RStudio Connect about the email output. Several \verb{rsc_*} fields
 exist to specify different components of the email, which can be set in the
 YAML header or programmatically using \code{rmarkdown::output_metadata()}. See the
 \href{https://docs.rstudio.com/connect/1.7.2/user/r-markdown.html}{RStudio Connect documentation}
@@ -76,23 +82,33 @@ yml() \%>\%
   )
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/yml_rticles_opts.Rd
+++ b/man/yml_rticles_opts.Rd
@@ -7,26 +7,42 @@
 \alias{rticles_corr_author}
 \title{Set YAML related to rticles output formats}
 \usage{
-yml_rticles_opts(.yml, title = yml_blank(), runninghead = yml_blank(),
-  author = yml_blank(), authormark = yml_blank(),
-  address = yml_blank(), corrauth = yml_blank(),
-  corres = yml_blank(), email = yml_blank(), abstract = yml_blank(),
-  received = yml_blank(), revised = yml_blank(),
-  accepted = yml_blank(), keywords = yml_blank(),
-  bibliography = yml_blank(), longtable = yml_blank(),
-  classoption = yml_blank(), header_includes = yml_blank(),
-  include_after = yml_blank(), ...)
+yml_rticles_opts(
+  .yml,
+  title = yml_blank(),
+  runninghead = yml_blank(),
+  author = yml_blank(),
+  authormark = yml_blank(),
+  address = yml_blank(),
+  corrauth = yml_blank(),
+  corres = yml_blank(),
+  email = yml_blank(),
+  abstract = yml_blank(),
+  received = yml_blank(),
+  revised = yml_blank(),
+  accepted = yml_blank(),
+  keywords = yml_blank(),
+  bibliography = yml_blank(),
+  longtable = yml_blank(),
+  classoption = yml_blank(),
+  header_includes = yml_blank(),
+  include_after = yml_blank(),
+  ...
+)
 
 rticles_author(name = yml_blank(), num = yml_blank())
 
 rticles_address(name = yml_blank(), org = yml_blank())
 
-rticles_corr_author(name = yml_blank(), author = yml_blank(),
-  address = yml_blank())
+rticles_corr_author(
+  name = yml_blank(),
+  author = yml_blank(),
+  address = yml_blank()
+)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{title}{Title of the manuscript}
 
@@ -69,11 +85,11 @@ pandoc to convert markdown to LaTeX code (sim_article)}
 \code{sagej} class (sage_article)}
 
 \item{header_includes}{additional LaTeX code to include in the header, before
-the \code{\\begin\{document\}} statement (sage_article, sim_article). Note that
+the \verb{\\\\begin\\\{document\\\}} statement (sage_article, sim_article). Note that
 the actual YAML field is \code{header-includes}}
 
 \item{include_after}{additional LaTeX code to include before the
-\code{\\end\{document\}} statement (sage_article, sim_article). Note that the
+\verb{\\\\end\\\{document\\\}} statement (sage_article, sim_article). Note that the
 actual YAML field is \code{include-after}.}
 
 \item{...}{additional named R objects, such as characters or lists, to
@@ -102,23 +118,33 @@ yml() \%>\%
 
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}, \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/yml_runtime.Rd
+++ b/man/yml_runtime.Rd
@@ -8,7 +8,7 @@ yml_runtime(.yml, runtime = c("static", "shiny", "shiny_prerendered"))
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{runtime}{The runtime target for rendering. \code{static}, the default,
 renders static documents; \code{shiny} allows you to include use Shiny in your
@@ -31,31 +31,43 @@ yml() \%>\%
 
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_site_opts}}, \code{\link{yml_toc}},
-  \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 
-Other R Markdown: \code{\link{yml_clean}},
-  \code{\link{yml_params}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_vignette}}
+Other R Markdown: 
+\code{\link{yml_clean}()},
+\code{\link{yml_params}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_vignette}()}
 
-Other shiny: \code{\link{yml_params}}
+Other shiny: 
+\code{\link{yml_params}()}
 }
 \concept{R Markdown}
 \concept{shiny}

--- a/man/yml_site_opts.Rd
+++ b/man/yml_site_opts.Rd
@@ -5,23 +5,41 @@
 \alias{yml_navbar}
 \alias{navbar_page}
 \alias{navbar_separator}
-\title{Add site options for \code{_site.yml} and navbars for R Markdown websites}
+\title{Add site options for \verb{_site.yml} and navbars for R Markdown websites}
 \usage{
-yml_site_opts(.yml, name = yml_blank(), favicon = yml_blank(),
-  output_dir = yml_blank(), include = yml_blank(),
-  exclude = yml_blank(), new_session = yml_blank(), ...)
+yml_site_opts(
+  .yml,
+  name = yml_blank(),
+  favicon = yml_blank(),
+  output_dir = yml_blank(),
+  include = yml_blank(),
+  exclude = yml_blank(),
+  new_session = yml_blank(),
+  ...
+)
 
-yml_navbar(.yml, title = yml_blank(), type = yml_blank(),
-  left = yml_blank(), right = yml_blank(), ...)
+yml_navbar(
+  .yml,
+  title = yml_blank(),
+  type = yml_blank(),
+  left = yml_blank(),
+  right = yml_blank(),
+  ...
+)
 
-navbar_page(text = yml_blank(), href = yml_blank(),
-  icon = yml_blank(), menu = yml_blank(), ...)
+navbar_page(
+  text = yml_blank(),
+  href = yml_blank(),
+  icon = yml_blank(),
+  menu = yml_blank(),
+  ...
+)
 
 navbar_separator()
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{name}{The name of the website}
 
@@ -31,7 +49,7 @@ a \code{yml_*()} function}
 if none is specified)}
 
 \item{include, exclude}{Files to include or exclude from the copied into
-\code{output_dir}. You can use \code{*} to indicate a wildcard selection, e.g.
+\code{output_dir}. You can use \verb{*} to indicate a wildcard selection, e.g.
 "*.csv".}
 
 \item{new_session}{Logical. Should each website file be rendered in a new
@@ -60,15 +78,15 @@ a \code{yml} object
 \description{
 R Markdown has a simple website builder baked in (see the R \href{https://bookdown.org/yihui/rmarkdown/rmarkdown-site.html#site_navigation}{Markdown book}
 for a detailed description). An R Markdown website must have at least have an
-\code{index.Rmd} file and a \code{_site.yml} file (which can be empty). Including YAML
-in \code{_site.yml} will apply it to all R Markdown files for the website, e.g.
+\code{index.Rmd} file and a \verb{_site.yml} file (which can be empty). Including YAML
+in \verb{_site.yml} will apply it to all R Markdown files for the website, e.g.
 setting the output format here will tell R Markdown to use that format across
 the website. R Markdown websites also support navbars, which you can specify
 with YAML (see \code{\link[=yml_navbar]{yml_navbar()}}, as well as ?rmarkdown::render_site and
 ?rmarkdown::html_document). Pass \code{navbar_page()} to the \code{left} or \code{right}
 field to set up page tabs and use \code{navbar_separator()} to include a
-separators. In addition to writing YAML with \code{yml_*()} functions,
-\code{use_site_yml()} will take the a \code{yml} object and write it to a \code{_site.yml}
+separators. In addition to writing YAML with \verb{yml_*()} functions,
+\code{use_site_yml()} will take the a \code{yml} object and write it to a \verb{_site.yml}
 file for you.
 }
 \examples{
@@ -92,32 +110,44 @@ yml_empty() \%>\%
 \seealso{
 \code{\link[=use_site_yml]{use_site_yml()}} \code{\link[=use_navbar_yml]{use_navbar_yml()}} \code{\link[=use_index_rmd]{use_index_rmd()}}
 
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_toc}},
-  \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_toc}()},
+\code{\link{yml_vignette}()}
 
-Other R Markdown: \code{\link{yml_clean}},
-  \code{\link{yml_params}}, \code{\link{yml_runtime}},
-  \code{\link{yml_vignette}}
+Other R Markdown: 
+\code{\link{yml_clean}()},
+\code{\link{yml_params}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_vignette}()}
 
-Other websites: \code{\link{yml_distill_opts}},
-  \code{\link{yml_pkgdown}}
+Other websites: 
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_pkgdown}()}
 }
 \concept{R Markdown}
 \concept{websites}

--- a/man/yml_toc.Rd
+++ b/man/yml_toc.Rd
@@ -4,12 +4,17 @@
 \alias{yml_toc}
 \title{Specify Table of Contents options}
 \usage{
-yml_toc(.yml, toc = yml_blank(), toc_depth = yml_blank(),
-  toc_title = yml_blank(), ...)
+yml_toc(
+  .yml,
+  toc = yml_blank(),
+  toc_depth = yml_blank(),
+  toc_title = yml_blank(),
+  ...
+)
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{toc}{Logical. Use a Table of Contents?}
 
@@ -37,24 +42,33 @@ yml() \%>\%
 
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_vignette}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_vignette}()}
 }
 \concept{yml}

--- a/man/yml_verbatim.Rd
+++ b/man/yml_verbatim.Rd
@@ -14,7 +14,7 @@ an object of class \code{verbatim}
 }
 \description{
 \code{yml_verbatim()} is a helper function to write YAML precisely as given to the
-\code{yml_*()} function rather than the defaults in ymlthis and yaml. ymlthis uses
+\verb{yml_*()} function rather than the defaults in ymlthis and yaml. ymlthis uses
 the yaml package to check for valid syntax; yaml and ymlthis together make
 decisions about how to write syntax, which can often be done in numerous
 valid ways. See \code{\link[yaml:as.yaml]{yaml::as.yaml()}} for more details.

--- a/man/yml_vignette.Rd
+++ b/man/yml_vignette.Rd
@@ -4,12 +4,11 @@
 \alias{yml_vignette}
 \title{Set up a package vignette}
 \usage{
-yml_vignette(.yml, title, engine = "knitr::rmarkdown",
-  encoding = "UTF-8")
+yml_vignette(.yml, title, engine = "knitr::rmarkdown", encoding = "UTF-8")
 }
 \arguments{
 \item{.yml}{a \code{yml} object created by \code{yml()}, \code{as_yml()}, or returned by
-a \code{yml_*()} function}
+a \verb{yml_*()} function}
 
 \item{title}{The title of the vignette}
 
@@ -37,29 +36,40 @@ yml() \%>\%
 
 }
 \seealso{
-Other yml: \code{\link{asis_yaml_output}},
-  \code{\link{bib2yml}}, \code{\link{draw_yml_tree}},
-  \code{\link{has_field}}, \code{\link{read_json}},
-  \code{\link{use_yml_defaults}},
-  \code{\link{use_yml_file}}, \code{\link{use_yml}},
-  \code{\link{yml_author}},
-  \code{\link{yml_blogdown_opts}},
-  \code{\link{yml_bookdown_opts}},
-  \code{\link{yml_citations}}, \code{\link{yml_clean}},
-  \code{\link{yml_distill_opts}},
-  \code{\link{yml_latex_opts}}, \code{\link{yml_output}},
-  \code{\link{yml_pagedown_opts}},
-  \code{\link{yml_params}}, \code{\link{yml_pkgdown}},
-  \code{\link{yml_reference}}, \code{\link{yml_replace}},
-  \code{\link{yml_resource_files}},
-  \code{\link{yml_rsconnect_email}},
-  \code{\link{yml_rticles_opts}},
-  \code{\link{yml_runtime}}, \code{\link{yml_site_opts}},
-  \code{\link{yml_toc}}
+Other yml: 
+\code{\link{asis_yaml_output}()},
+\code{\link{bib2yml}()},
+\code{\link{draw_yml_tree}()},
+\code{\link{has_field}()},
+\code{\link{read_json}()},
+\code{\link{use_yml_defaults}()},
+\code{\link{use_yml_file}()},
+\code{\link{use_yml}()},
+\code{\link{yml_author}()},
+\code{\link{yml_blogdown_opts}()},
+\code{\link{yml_bookdown_opts}()},
+\code{\link{yml_citations}()},
+\code{\link{yml_clean}()},
+\code{\link{yml_distill_opts}()},
+\code{\link{yml_latex_opts}()},
+\code{\link{yml_output}()},
+\code{\link{yml_pagedown_opts}()},
+\code{\link{yml_params}()},
+\code{\link{yml_pkgdown}()},
+\code{\link{yml_reference}()},
+\code{\link{yml_replace}()},
+\code{\link{yml_resource_files}()},
+\code{\link{yml_rsconnect_email}()},
+\code{\link{yml_rticles_opts}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()},
+\code{\link{yml_toc}()}
 
-Other R Markdown: \code{\link{yml_clean}},
-  \code{\link{yml_params}}, \code{\link{yml_runtime}},
-  \code{\link{yml_site_opts}}
+Other R Markdown: 
+\code{\link{yml_clean}()},
+\code{\link{yml_params}()},
+\code{\link{yml_runtime}()},
+\code{\link{yml_site_opts}()}
 }
 \concept{R Markdown}
 \concept{yml}

--- a/vignettes/yaml-fieldguide.Rmd
+++ b/vignettes/yaml-fieldguide.Rmd
@@ -39,23 +39,27 @@ library(ymlthis)
 oldoption <- options(devtools.name = "Malcolm Barrett")
 
 function_name <- function(x) {
-  function_call <- as.character(attr(x, "call"))
-  ifelse(rlang::has_length(function_call), function_call[[2]], NA)
+  function_call <- x$call
+  ifelse(rlang::has_length(function_call), as.character(function_call[[2]]), NA)
 }
 
+block_names <- function(x) x$tags %>% purrr::map_chr(~.x$tag)
+
 get_doc_name <- function(x) {
-  doc_name <- x[["rdname"]]
-  if (is.null(doc_name)) doc_name <- function_name(x)
-  doc_name
+  tags <- block_names(x)
+  rdname_index <- which(tags == "rdname")
+  if (purrr::is_empty(rdname_index)) return(function_name(x))
+  
+  x$tags[[rdname_index]]$val
 }
 
 get_params <- function(x) {
-  param_lists <- which(names(x) == "param")
+  param_lists <- which(block_names(x) == "param")
   f <- get_doc_name(x)
   if (!rlang::has_length(param_lists) || is.na(f)) return(data.frame())
   
-  params_desc <- x[param_lists] %>% 
-    purrr::map(as.data.frame, stringsAsFactors = FALSE) %>% 
+  params_desc <- x$tags[param_lists] %>% 
+    purrr::map(~as.data.frame(.x$val, stringsAsFactors = FALSE)) %>% 
      do.call(rbind, .)
   
   params_desc$description <- stringr::str_replace_all(
@@ -74,7 +78,7 @@ get_params <- function(x) {
 }
 
 link_help_page <- function(x) {
-  glue::glue("<a href='https://r-lib.github.io/ymlthis/reference/{x}.html'>{x}</a>")
+  glue::glue("<a href='https://ymlthis.r-lib.org//reference/{x}.html'>{x}</a>")
 } 
 
 filter_kable <- function(.tbl, .pattern = NULL, caption = NULL) {


### PR DESCRIPTION
This PR updates the YAML Fieldguide, which populates using roxygen2, to use the new internal structure for roxygen blocks introduced in roxygen2 7.0.0. Closes #49.