### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/R/yml_citations.R
+++ b/R/yml_citations.R
@@ -95,7 +95,7 @@ yml_citations <- function(
 #'   ),
 #'   `container-title` = "Nature Materials",
 #'   volume = 11L,
-#'   URL = "http://dx.doi.org/10.1038/nmat3283",
+#'   URL = "https://doi.org/10.1038/nmat3283",
 #'   DOI = "10.1038/nmat3283",
 #'   issue = 4L,
 #'   publisher = "Nature Publishing Group",

--- a/man/yml_reference.Rd
+++ b/man/yml_reference.Rd
@@ -46,7 +46,7 @@ ref <- reference(
   ),
   `container-title` = "Nature Materials",
   volume = 11L,
-  URL = "http://dx.doi.org/10.1038/nmat3283",
+  URL = "https://doi.org/10.1038/nmat3283",
   DOI = "10.1038/nmat3283",
   issue = 4L,
   publisher = "Nature Publishing Group",

--- a/vignettes/introduction-to-ymlthis.Rmd
+++ b/vignettes/introduction-to-ymlthis.Rmd
@@ -152,7 +152,7 @@ ref <- reference(
   ),
   `container-title` = "Nature Materials",
   volume = 11L,
-  URL = "http://dx.doi.org/10.1038/nmat3283",
+  URL = "https://doi.org/10.1038/nmat3283",
   DOI = "10.1038/nmat3283",
   issue = 4L,
   publisher = "Nature Publishing Group",


### PR DESCRIPTION
The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.