### PR TITLE
Corrected miniIU typo to miniUI in addins.R

### DIFF
--- a/R/addins.R
+++ b/R/addins.R
@@ -1,6 +1,6 @@
 #' @importFrom utils getFromNamespace
 launch_yaml_addin <- function() {
-  stop_if_not_installed(c("miniIU", "shinyBS"))
+  stop_if_not_installed(c("miniUI", "shinyBS"))
   addin_dir <- system.file("addin", "new_yaml", package = "ymlthis")
   app <- shiny::shinyAppDir(addin_dir)
   shiny::runGadget(
@@ -8,3 +8,4 @@ launch_yaml_addin <- function() {
     viewer = shiny::dialogViewer("New YAML", height = 700)
   )
 }
+


### PR DESCRIPTION
Attempting to use package was resulting in this message:

```
> library(miniUI)
> ymlthis:::launch_yaml_addin()
ℹ The package `miniIU` is required Must be installed to use this function.
✖ Would you like to install it?

1: Yes
2: No

Selection: 
```

This was a result of a typo in the "addins.R" file which I have corrected.

Closes #84 